### PR TITLE
Add communication command for balancing selftest.

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -35,6 +35,7 @@
 #include "bm_if.h"
 #endif
 #include "minilzo.h"
+#include "selftest.h"
 
 #include <math.h>
 #include <string.h>
@@ -472,6 +473,19 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 
 	case COMM_BMS_HW_DATA: {
 		HW_SEND_DATA(reply_func);
+	} break;
+
+	case COMM_BALANCE_SELFTEST: {
+		int32_t ind;
+		int32_t len;
+
+		chMtxLock(&send_buffer_mutex);
+		ind = 0;
+		send_buffer_global[ind++] = packet_id;
+		len = selftest_serialize_result(send_buffer_global + ind, (sizeof(send_buffer_global) - ind));
+		reply_func(send_buffer_global, ind + len);
+
+		chMtxUnlock(&send_buffer_mutex);
 	} break;
 
 		// Blocking commands. Only one of them runs at any given time, in their

--- a/datatypes.h
+++ b/datatypes.h
@@ -476,6 +476,8 @@ typedef enum {
 
 	COMM_BMS_FWD_CAN_RX,
 	COMM_BMS_HW_DATA,
+
+	COMM_BALANCE_SELFTEST,
 } COMM_PACKET_ID;
 
 #endif /* DATATYPES_H_ */

--- a/drivers/ltc6813.h
+++ b/drivers/ltc6813.h
@@ -35,6 +35,8 @@ bool ltc_get_dsc(int cell);
 void ltc_sleep(void);
 bool ltc_self_test(void);
 
+#define LTC_MAX_NBR_CELLS           18
+
 // Commands
 #define LTC_ADCV					0x0260
 #define LTC_ADOW					0x0228

--- a/selftest.c
+++ b/selftest.c
@@ -44,7 +44,8 @@ static void terminal_st(int argc, const char **argv) {
 
 	commands_printf("Testing LTC6813... %s\n", res_ok ? "Ok" : "Failed");
 
-	for (int i = 0;i < backup.config.cell_num;i++) {
+	for (int i = backup.config.cell_first_index;
+			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
 		bms_if_set_balance_override(i, 1);
 	}
 
@@ -82,8 +83,13 @@ static void terminal_st(int argc, const char **argv) {
 			res_ok = false;
 		}
 
-		bms_if_set_balance_override(i, 0);
+		bms_if_set_balance_override(i, 1);
 		ltc_set_dsc(i, 0);
+	}
+
+	for (int i = backup.config.cell_first_index;
+			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
+		bms_if_set_balance_override(i, 0);
 	}
 
 	commands_printf(res_ok ? "\nAll tests passed!\n" : "\nOne or more tests failed...\n");

--- a/selftest.c
+++ b/selftest.c
@@ -25,6 +25,7 @@
 #include "main.h"
 #include "ch.h"
 #include "hal.h"
+#include "buffer.h"
 
 typedef struct {
 	float no_bal;
@@ -113,4 +114,29 @@ static void terminal_st(int argc, const char **argv) {
 	}
 
 	commands_printf(res_ok ? "\nAll tests passed!\n" : "\nOne or more tests failed...\n");
+}
+
+int32_t selftest_serialize_result(uint8_t *buffer, uint32_t buffer_size) {
+	cell_test_voltage_t cell_v[LTC_MAX_NBR_CELLS];
+	int32_t len;
+	bool res_ok;
+
+	if (buffer_size < (sizeof(uint16_t) +
+			((backup.config.cell_num - backup.config.cell_first_index) * sizeof(float))))
+		return 0;
+
+	len = 0;
+	res_ok = ltc_self_test();
+	buffer_append_int16(buffer, res_ok, &len);
+
+	if (balancing_selftest(cell_v) < 0)
+		return len;
+
+	for (int i = backup.config.cell_first_index;
+			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
+		buffer_append_float32_auto(buffer, cell_v[i].no_bal, &len);
+		buffer_append_float32_auto(buffer, cell_v[i].bal, &len);
+	}
+
+	return len;
 }

--- a/selftest.c
+++ b/selftest.c
@@ -26,6 +26,11 @@
 #include "ch.h"
 #include "hal.h"
 
+typedef struct {
+	float no_bal;
+	float bal;
+} cell_test_voltage_t;
+
 // Private functions
 static void terminal_st(int argc, const char **argv);
 
@@ -37,12 +42,9 @@ void selftest_init(void) {
 			terminal_st);
 }
 
-static void terminal_st(int argc, const char **argv) {
-	(void)argc; (void)argv;
-
-	bool res_ok = ltc_self_test();
-
-	commands_printf("Testing LTC6813... %s\n", res_ok ? "Ok" : "Failed");
+static int32_t balancing_selftest(cell_test_voltage_t *p_test_v) {
+	if ((backup.config.cell_first_index + backup.config.cell_num) >= LTC_MAX_NBR_CELLS)
+		return -1;
 
 	for (int i = backup.config.cell_first_index;
 			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
@@ -51,37 +53,14 @@ static void terminal_st(int argc, const char **argv) {
 
 	chThdSleepMilliseconds(500);
 
-	commands_printf("Testing balancing and open connections...\n");
-	commands_printf("Cell NoBal   Bal     Diff    Result");
-	commands_printf("===================================");
-
 	for (int i = backup.config.cell_first_index;
 			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
 		bms_if_set_balance_override(i, 2);
 		ltc_set_dsc(i, 1);
 		chThdSleepMilliseconds(200);
 
-		float no_bal = ltc_last_cell_voltage(i);
-		float bal = ltc_last_cell_voltage_no_mute(i);
-		float diff = fabsf(bal - no_bal);
-		bool ok = (diff / no_bal > 0.03 && bal > 2.0);
-
-#ifdef HW_NO_CH0_TEST
-		if (i == 0) {
-			ok = bal > 2.0;
-		}
-#endif
-
-		commands_printf("%02d   %.4f  %.4f  %.4f  %s",
-				i + 1,
-				no_bal,
-				bal,
-				diff,
-				ok ? "Ok" : "Failed");
-
-		if (!ok) {
-			res_ok = false;
-		}
+		p_test_v[i].no_bal = ltc_last_cell_voltage(i);
+		p_test_v[i].bal = ltc_last_cell_voltage_no_mute(i);
 
 		bms_if_set_balance_override(i, 1);
 		ltc_set_dsc(i, 0);
@@ -90,6 +69,47 @@ static void terminal_st(int argc, const char **argv) {
 	for (int i = backup.config.cell_first_index;
 			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
 		bms_if_set_balance_override(i, 0);
+	}
+
+	return 0;
+}
+
+static void terminal_st(int argc, const char **argv) {
+	(void)argc; (void)argv;
+
+	cell_test_voltage_t cell_v[LTC_MAX_NBR_CELLS];
+	bool res_ok = ltc_self_test();
+
+	commands_printf("Testing LTC6813... %s\n", res_ok ? "Ok" : "Failed");
+
+	balancing_selftest(cell_v);
+
+	commands_printf("Testing balancing and open connections...\n");
+	commands_printf("Cell NoBal   Bal     Diff    Result");
+	commands_printf("===================================");
+
+	for (int i = backup.config.cell_first_index;
+			i < (backup.config.cell_first_index + backup.config.cell_num);i++) {
+
+		float diff = fabsf(cell_v[i].bal - cell_v[i].no_bal);
+		bool ok = (diff / cell_v[i].no_bal > 0.03 && cell_v[i].bal > 2.0);
+
+#ifdef HW_NO_CH0_TEST
+		if (i == 0) {
+			ok = cell_v[i].bal > 2.0;
+		}
+#endif
+
+		commands_printf("%02d   %.4f  %.4f  %.4f  %s",
+				i + 1,
+				cell_v[i].no_bal,
+				cell_v[i].bal,
+				diff,
+				ok ? "Ok" : "Failed");
+
+		if (!ok) {
+			res_ok = false;
+		}
 	}
 
 	commands_printf(res_ok ? "\nAll tests passed!\n" : "\nOne or more tests failed...\n");

--- a/selftest.h
+++ b/selftest.h
@@ -20,7 +20,10 @@
 #ifndef SELFTEST_H_
 #define SELFTEST_H_
 
+#include <stdio.h>
+
 // Functions
 void selftest_init(void);
+int32_t selftest_serialize_result(uint8_t *buffer, uint32_t buffer_size);
 
 #endif /* SELFTEST_H_ */


### PR DESCRIPTION
With this change, a communication command is added to run the balancing selftest, in addition to the existing Vesc tool terminal command.
The command COMM_BALANCE_SELFTEST will return the measured voltage values, so the caller can determine if the test has passed or failed.